### PR TITLE
improve error handling

### DIFF
--- a/src/app/shared/forge.service.ts
+++ b/src/app/shared/forge.service.ts
@@ -93,8 +93,11 @@ export class ForgeService {
       .catch(this.handleError);
   }
 
-  private handleError(error: any): Promise<any> {
+  private handleError(error: Response | any): Promise<any> {
     console.error('An error occurred', error);
+    if (error.json) {
+      return Promise.reject(error.json());
+    }
     return Promise.reject(error.message || "Error calling service");
   }
 }

--- a/src/app/shared/model.ts
+++ b/src/app/shared/model.ts
@@ -157,7 +157,7 @@ export class StatusEvent {
 export class StatusMessage {
     messageKey: string;
     message: string;
-    data: Map<string, any>;
+    data: any;
     done: boolean;
 
     constructor(messageKey: string, message: string) {


### PR DESCRIPTION
@gastaldi in the case we had yesterday where we get a 200 response code back with the html:
```html
<html><head><title>Error</title></head><body>Internal Server Error</body></html>
```
The error will be written in the page like this:
`Uncaught SyntaxError: Unexpected token < in JSON at position 0`

That is better but we might want to have a non 200 status code and a better message

The 412 we had yesterday will be displayed nice now